### PR TITLE
Remove `bin/update` script and update docs accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ To set up a new machine, first clone this repository and then run the included `
 bin/setup
 ```
 
-When you notice that the origin/master is updated, run the `bin/update` at the edge commit:
-
-```bash
-bin/update
-```
+When you notice that the origin/master is updated, run `bin/setup` again at the edge commit.
 
 ## Badge
 

--- a/bin/update
+++ b/bin/update
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Absolute path of flywheel-jp/flywheel-standard repository
-REPOSITORY_DIR=$(cd $(dirname $0); cd ..; pwd)
-
-# Run bin/setup
-. $REPOSITORY_DIR/bin/setup

--- a/docs/local_environment.md
+++ b/docs/local_environment.md
@@ -14,7 +14,7 @@ installed the latest version of the following tools:
 * :rocket: [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/)
 * :rocket: [jsonnet](https://jsonnet.org/)
 
-:rocket: indicates `bin/setup` and `bin/update` install it.
+:rocket: indicates `bin/setup` in this repository installs it.
 
 ## Prefer Version Manager Over Language Version
 
@@ -36,8 +36,8 @@ and executable binaries such as `protoc` make sense to run in Docker.
 
 If it is difficult or inconvenient to use Docker, we MAY ask developers to install non-standard
 dependencies to their local environment. For example, flywheel-jp/flywheel-terraform expects
-locally installed `terraform`. In this case, however, these dependencies SHOULD be installed and maintained by
-`bin/setup` and `bin/update`; otherwise, we MUST explain how to install them in README.
+locally installed `terraform`. In this case, however, such dependencies SHOULD be installed and maintained by
+`bin/setup` in that repository; otherwise, we MUST explain how to install them in README.
 We SHOULD document how to uninstall them as well.
 
 ## Related Standards

--- a/docs/setup_scripts.md
+++ b/docs/setup_scripts.md
@@ -1,23 +1,15 @@
 # Setup Scripts
 
-Each repository MUST provide two scripts: `bin/setup` and `bin/update`.
-
-`bin/setup` is intended to run only once on a machine. After that, `bin/update` is
-executed instead. Both of them MAY assume the machine is correctly set up as
-described in the [Local Environment](./local_environment.md) standard.
-
-## `bin/setup`
+Each repository MUST provide one script: `bin/setup`.
 
 `bin/setup` provisions a local machine for developing the repository containing the script.
+In general, it resolves dependencies such as git submodules, npm packages, and so on.
+It MAY assume the machine is correctly set up as described in the
+[Local Environment](./local_environment.md) standard.
 
-In general, it resolves dependencies, such as git submodules, npm packages, and so on.
+Since a developer MAY run it multiple times, it MUST have idempotency.
 
-## `bin/update`
-
-`bin/update` MAY assume that the `bin/setup` has ever been executed on the machine. Since
-a developer MAY run it multiple times, it MUST have idempotency.
-
-In addition to update dependencies, it SHOULD do known workarounds for fixing predictable
+In addition to setting up dependencies, it SHOULD do known workarounds for fixing predictable
 common issues if available. For example, if the software depends on a local cache while
 development, it MAY clean up the cache because the broken cache could be a root cause of
 many issues.
@@ -26,17 +18,17 @@ In other words, when a developer faces a strange behavior of the software, the p
 SHOULD run this script to attempt to fix the issue before asking a coworker or filing
 a ticket.
 
-## Standard's `bin/setup` and `bin/update`
+## Standard's `bin/setup`
 
-flywheel-jp/flywheel-standard contains `bin/setup` and `bin/update` which set up a local
-machine to be compliant with the [Local Environment](./local_environment.md) standard.
+flywheel-jp/flywheel-standard contains `bin/setup` which sets up a local machine to be compliant
+with the [Local Environment](./local_environment.md) standard.
 Consequently, if a repository is compliant with this standard, we can theoretically get
 started with development by doing the following steps:
 
 1. Checkout the current origin/master of flywheel-jp/flywheel-standard.
-2. Run `bin/setup` or `bin/update`.
+2. Run `bin/setup` in flywheel-jp/flywheel-standard repository.
 3. Clone the repository you want to start contributing to.
-4. Run `bin/setup`.
+4. Run `bin/setup` in that repository.
 
 ## Related Standards
 


### PR DESCRIPTION
# Why

The reason copied from [my previous comment](https://github.com/flywheel-jp/distributed-fetcher/pull/61#discussion_r331831563):
- Even in the current rule, `bin/setup` (as well as `bin/update`) must be idempotent.
    - Suppose you've worked on project A, which requires dependency X and Y.
       Now you start working on project B, which requires dependency X and Z.
       Your machine has X installed, and B's `bin/setup` should successfully install dependency Z.
- Fortunately implementing idempotency for this kind of tasks is not that difficult since:
    - Tools such as `brew bundle` already implements this for us; most of the time we just invoke these tools.

# Ref

https://flywheel-jp.atlassian.net/browse/EN-55