### PR TITLE
Add bash to the standard

### DIFF
--- a/Brewfile.macos
+++ b/Brewfile.macos
@@ -5,6 +5,7 @@ cask_args appdir: "/Applications"
 tap "homebrew/cask"
 cask "docker"
 
+brew "bash"
 brew "git"
 brew "kubectl"
 brew "nodenv"

--- a/docs/local_environment.md
+++ b/docs/local_environment.md
@@ -4,6 +4,7 @@ Each repository MAY assume that a developer's local environment has correctly
 installed the latest version of the following tools:
 
 * :rocket: [Homebrew]
+* :rocket: [bash](https://www.gnu.org/software/bash/)
 * :rocket: [git](https://git-scm.com/)
 * :rocket: [Docker](https://www.docker.com/)
 * :rocket: [AdoptOpenJDK 8](https://adoptopenjdk.net/)


### PR DESCRIPTION
Add bash to the brewfile.  As is well known, /bin/bash preinstalled in macos is far old.

For my env as of today,
- /bin/bash is `3.2.57(1)-release-(x86_64-apple-darwin19)`
- brew installed `5.0.16(1)-release-(x86_64-apple-darwin19.3.0)`