### PR TITLE
Fix upload workflow to stop using deleted action

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,23 +1,21 @@
 name: upload
 on:
   push:
-    branches:
-      - master
+    branches: [master]
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: GCP Authenticate
-        uses: actions/gcloud/auth@master
-        env:
-          GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
-      # gsutil skips symlink directory "public/docs"
-      - name: Upload documents to flywheel-mouseion bucket
-        uses: docker://gcr.io/cloud-builders/gsutil
+      # flywheel-jp/mouseion/upload internally uses gsutil and gsutil
+      # skips symlink directory "public/docs"
+      - uses: flywheel-jp/mouseion/upload@master
         with:
-          args: -m rsync -d -r public gs://flywheel-mouseion/flywheel-standard
-      # ... so sync "public/docs" directory manually.
-      - uses: docker://gcr.io/cloud-builders/gsutil
+          service-account-key: ${{ secrets.GCLOUD_AUTH }}
+          source: public
+      # ... so upload "public/docs" directory.
+      - uses: flywheel-jp/mouseion/upload@master
         with:
-          args: -m rsync -d -r public/docs gs://flywheel-mouseion/flywheel-standard/docs
+          service-account-key: ${{ secrets.GCLOUD_AUTH }}
+          namespace: flywheel-standard/docs
+          source: public/docs


### PR DESCRIPTION
## What
TSIA

## Why
https://github.com/actions/gcloud was deleted.

## QA
Allow the upload workflow to run against `fix-ci` branch temporally and confirm documents are uploaded to Mouseion correctly. https://github.com/flywheel-jp/flywheel-standard/runs/502426507

## Ref
* https://github.com/flywheel-jp/flywheel-standard/runs/502413862?check_suite_focus=true